### PR TITLE
privacy publish was updated

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm i
         env:
           NPM_TOKEN: ${{ secrets.npm_token }}
-      - run: npm publish --access private
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 


### PR DESCRIPTION
Se modificó la flag de privacidad en la action `npm-publish` para que el repo pase a estar público en npm.