### PR TITLE
feat: add key janisEnv

### DIFF
--- a/lib/deviceInfo.js
+++ b/lib/deviceInfo.js
@@ -24,10 +24,6 @@ const getEnvironment = () => {
 	const everySegmentHasText = bundleSegments.every((bundleSegment) => bundleSegment.length > 0);
 	if (!everySegmentHasText) return null;
 
-	const hasJanisShape =
-		bundleSegments.length >= 3 && bundleSegments[0] === 'in' && bundleSegments[1] === 'janis';
-	if (!hasJanisShape) return null;
-
 	const lastBundleSegment = bundleSegments[bundleSegments.length - 1];
 	if (lastBundleSegment === 'beta') return 'janisdev';
 	if (lastBundleSegment === 'qa') return 'janisqa';

--- a/lib/deviceInfo.js
+++ b/lib/deviceInfo.js
@@ -11,6 +11,29 @@ import {
 } from 'react-native-device-info';
 import {Dimensions, PixelRatio} from 'react-native';
 
+// Last segment must be exactly beta|qa (not endsWith) so e.g. betabeta is not janisdev.
+const JANIS_BUNDLE_PREFIX = 'in.janis.';
+
+const getEnvironment = () => {
+	const normalizedBundleId = String(getBundleId() ?? '')
+		.trim()
+		.toLowerCase();
+	if (!normalizedBundleId.startsWith(JANIS_BUNDLE_PREFIX)) return null;
+
+	const bundleSegments = normalizedBundleId.split('.');
+	const everySegmentHasText = bundleSegments.every((bundleSegment) => bundleSegment.length > 0);
+	if (!everySegmentHasText) return null;
+
+	const hasJanisShape =
+		bundleSegments.length >= 3 && bundleSegments[0] === 'in' && bundleSegments[1] === 'janis';
+	if (!hasJanisShape) return null;
+
+	const lastBundleSegment = bundleSegments[bundleSegments.length - 1];
+	if (lastBundleSegment === 'beta') return 'janisdev';
+	if (lastBundleSegment === 'qa') return 'janisqa';
+	return 'janis';
+};
+
 /***
  * @name getDeviceModel
  * @description returns a string that represent device brand and model
@@ -75,20 +98,22 @@ export const getDeviceInfoForHeaders = () => ({
 
 /***
  * @name getAppInfo
- * @description returns an object with the app name and environment
- * @returns {object}
+ * @returns {{
+ *   appName: string;
+ *   janisEnv: string;
+ * }}
+ * @property {string} appName `AppInfo.appName` — display name from the OS (`getApplicationName`). Empty string if unavailable.
+ * @property {string} janisEnv `AppInfo.janisEnv` — `JANIS_ENV` in `@janiscommerce/app-request` (host / URL segment): `janis`, `janisdev`, or `janisqa`; empty string if the bundle is not a valid Janis app (`in.janis.*` rules).
  * @example getAppInfo() => {
  *  appName: 'Janis Orders App',
- *  environment: 'qa',
+ *  janisEnv: 'janisqa',
  * }
  */
 export const getAppInfo = () => {
 	const appName = getApplicationName() || '';
-	const bundleId = getBundleId() || '';
-	const environment = !!bundleId ? bundleId.split('.')[3] || 'prod' : '';
 
 	return {
 		appName,
-		environment,
+		janisEnv: getEnvironment() ?? '',
 	};
 };

--- a/test/deviceInfo.test.js
+++ b/test/deviceInfo.test.js
@@ -108,10 +108,14 @@ describe('DeviceInfo utils:', () => {
 
 	describe('getAppInfo', () => {
 		it.each([
-			['im.janis.picking.beta', 'beta'],
-			['im.janis.picking.qa', 'qa'],
-			['im.janis.picking', 'prod'],
-		])('returns an object with the app name and environment', (bundleId, environment) => {
+			['in.janis.picking.beta', 'janisdev'],
+			['in.janis.picking.qa', 'janisqa'],
+			['in.janis.picking', 'janis'],
+			['IN.JANIS.PICKING.BETA', 'janisdev'],
+			['in.janis.picking.extra.beta', 'janisdev'],
+			['in.janis.picking.staging', 'janis'],
+			['in.janis.picking.betabeta', 'janis'],
+		])('returns app name and janisEnv from bundle id', (bundleId, janisEnv) => {
 			getApplicationNameSpy.mockReturnValueOnce('Janis Orders App');
 			getBundleIdSpy.mockReturnValueOnce(bundleId);
 
@@ -119,7 +123,7 @@ describe('DeviceInfo utils:', () => {
 
 			expect(appInfo).toStrictEqual({
 				appName: 'Janis Orders App',
-				environment,
+				janisEnv,
 			});
 		});
 
@@ -131,7 +135,25 @@ describe('DeviceInfo utils:', () => {
 
 			expect(appInfo).toStrictEqual({
 				appName: '',
-				environment: '',
+				janisEnv: '',
+			});
+		});
+
+		it.each([
+			['third-party bundle', 'com.example.otherapp', 'Other App'],
+			['empty bundle id', '', 'App'],
+			['bundle does not start with in.janis.', 'im.janis.picking.beta', 'App'],
+			['empty dot segment (in.janis.)', 'in.janis.', 'App'],
+			['double dots in bundle', 'in.janis..picking', 'App'],
+			['getBundleId returns non-string', 123, 'App'],
+			['getBundleId returns null', null, 'App'],
+		])('returns empty janisEnv — %s', (_caseLabel, bundleId, appName) => {
+			getApplicationNameSpy.mockReturnValueOnce(appName);
+			getBundleIdSpy.mockReturnValueOnce(bundleId);
+
+			expect(getAppInfo()).toStrictEqual({
+				appName,
+				janisEnv: '',
 			});
 		});
 	});

--- a/test/deviceInfo.test.js
+++ b/test/deviceInfo.test.js
@@ -115,6 +115,9 @@ describe('DeviceInfo utils:', () => {
 			['in.janis.picking.extra.beta', 'janisdev'],
 			['in.janis.picking.staging', 'janis'],
 			['in.janis.picking.betabeta', 'janis'],
+			['  in.janis.picking.beta  ', 'janisdev'],
+			[' \tin.janis.picking.qa\n ', 'janisqa'],
+			['  in.janis.picking  ', 'janis'],
 		])('returns app name and janisEnv from bundle id', (bundleId, janisEnv) => {
 			getApplicationNameSpy.mockReturnValueOnce('Janis Orders App');
 			getBundleIdSpy.mockReturnValueOnce(bundleId);
@@ -142,7 +145,9 @@ describe('DeviceInfo utils:', () => {
 		it.each([
 			['third-party bundle', 'com.example.otherapp', 'Other App'],
 			['empty bundle id', '', 'App'],
+			['whitespace-only bundle id (trimmed to empty)', '   \t  ', 'App'],
 			['bundle does not start with in.janis.', 'im.janis.picking.beta', 'App'],
+			['trimmed bundle still not Janis (im.janis)', '  im.janis.picking.beta  ', 'App'],
 			['empty dot segment (in.janis.)', 'in.janis.', 'App'],
 			['double dots in bundle', 'in.janis..picking', 'App'],
 			['getBundleId returns non-string', 123, 'App'],


### PR DESCRIPTION
# Pull request — `@janiscommerce/app-device-info`

## Descripción del requerimiento

Cada proyecto que usa `@janiscommerce/app-request` necesitaba obtener manualmente el valor de `JANIS_ENV` (`janis`, `janisqa`, `janisdev`) y pasarlo al constructor, repitiendo la misma lógica en varias apps. Esa detección encaja mejor en el paquete de información del dispositivo/app, donde ya se lee el bundle id.

## Descripción de la solución

- Se centraliza la resolución del ambiente Janis en **`getAppInfo()`**: el objeto devuelto incluye **`janisEnv`**, alineado con el parámetro `JANIS_ENV` de `Request` (segmento de host / URL).
- La detección es **interna** (`getEnvironment`): bundle normalizado (`String`, `trim`, `minúsculas`), debe comenzar con `in.janis.`, sin segmentos vacíos entre puntos, y el **último** segmento determina el valor: `beta` → `janisdev`, `qa` → `janisqa`, cualquier otro caso válido → `janis`; si no es un bundle Janis reconocido → cadena vacía (los consumidores pueden hacer `janisEnv || 'janis'` si aplica).
- Se evita el falso positivo de `endsWith('.beta')` (p. ej. último segmento `betabeta`).
- **`getAppInfo` pasa a exponer `janisEnv`** (valores alineados con `JANIS_ENV`) en lugar de `environment` (`prod` / `beta` / `qa`). El resto del paquete no cambia. Quien ya leyera `environment` debe usar `janisEnv` y, si hace falta el formato viejo, mapear en la app.
- JSDoc de `getAppInfo` documenta `AppInfo.appName` y `AppInfo.janisEnv` con tipo de retorno explícito para mejor hover en el IDE.
- Tests: casos válidos con `it.each`, casos “no Janis” agrupados, sin nombres de terceros en bundles de ejemplo.

**Uso sugerido con app-request:**

```js
import { getAppInfo } from '@janiscommerce/app-device-info';
import Request from '@janiscommerce/app-request';

const { janisEnv } = getAppInfo();
const api = new Request({ JANIS_ENV: janisEnv || 'janis' });
```

## Archivos a revisar

### Modificados

- `lib/deviceInfo.js`
- `test/deviceInfo.test.js`

### Agregados

- (ninguno)

### Eliminados

- (ninguno)

> Si en tu rama también tocaste `lib/index.js`, `package.json` u otros, sumalos acá antes de abrir el PR.

## Nivel de pruebas requerido

### Guía de niveles

| Marcar | Nivel    | Descripción                                                | Condiciones                                      |
| ------ | -------- | ---------------------------------------------------------- | ------------------------------------------------ |
| [ ]    | CRÍTICO | Cambios que afectan partes fundamentales o múltiples módulos | Generar APK. Perfil regular. Pruebas exhaustivas |
| [ ]    | ALTO     | Cambios en aspectos importantes pero no críticos           | Probar local o APK. Perfil regular               |
| [ ]    | MEDIO    | Cambios en parte del flujo o en un método exportado       | Validación local. Perfil dev                     |
| [X]    | BAJO     | Ajuste acotado a `getAppInfo`; el resto de la API igual     | Validación local. Perfil dev                     |

## Casos de prueba

### Caso 1: Bundle de producción Janis

**Pasos:**

1. App con bundle id `in.janis.picking` (último segmento distinto de `beta` / `qa`).
2. Llamar `getAppInfo()` y leer `janisEnv`.

**Resultado esperado:** `janisEnv === 'janis'`.

**Resultado obtenido:** _pendiente_

---

### Caso 2: Bundle beta

**Pasos:**

1. App con bundle id `in.janis.picking.beta` (o último segmento `beta` con prefijo válido).
2. Llamar `getAppInfo()`.

**Resultado esperado:** `janisEnv === 'janisdev'`.

**Resultado obtenido:** _pendiente_

---

### Caso 3: Bundle QA

**Pasos:**

1. App con bundle id `in.janis.picking.qa`.
2. Llamar `getAppInfo()`.

**Resultado esperado:** `janisEnv === 'janisqa'`.

**Resultado obtenido:** _pendiente_

---

### Caso 4: Valor explícito en Request (integración)

**Pasos:**

1. Instanciar `new Request({ JANIS_ENV: 'janisqa' })` sin depender del bundle.
2. Verificar que las requests usan el host QA.

**Resultado esperado:** Se respeta el valor explícito (comportamiento de app-request; acá solo se valida que `getAppInfo` no sea obligatorio si la app fija `JANIS_ENV`).

**Resultado obtenido:** _pendiente_

---

### Caso 5: Bundle que no es Janis

**Pasos:**

1. Bundle que no cumple reglas `in.janis.*` (p. ej. `com.example.otherapp`).
2. Llamar `getAppInfo()`.

**Resultado esperado:** `janisEnv === ''` (y la app puede usar `janisEnv || 'janis'` al construir `Request`).

**Resultado obtenido:** _pendiente_

## Evidencias

_pendiente_

## CHANGELOG

_Completar al merge / release (no suele versionarse en la misma rama que el feature)._

### Changed (propuesta)

- `getAppInfo` expone `janisEnv` (`janis` | `janisdev` | `janisqa` | `''`) inferido del bundle id (`in.janis.*`, último segmento `beta` / `qa`), en lugar de `environment` con `prod` / `beta` / `qa`. **[APPSRN-XXX](https://janiscommerce.atlassian.net/browse/APPSRN-XXX)**

### Notas para consumidores

- Usar `janisEnv` para armar `JANIS_ENV` en `Request`. Si algún código aún lee `environment`, actualizarlo a `janisEnv` (y mapear valores si aplica).
- Integración típica: `new Request({ JANIS_ENV: getAppInfo().janisEnv || 'janis' })`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced the prior environment value with a normalized "janisEnv" field for consistent app-variant identification across varied bundle ID formats (case-insensitive, trimmed, and validated).
* **Tests**
  * Expanded coverage to assert "janisEnv" behavior for valid, variant, malformed, empty, and non-string bundle IDs while preserving app name extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->